### PR TITLE
Feature: Support folding reasoning content for thinking model

### DIFF
--- a/contrib/chat-plugin/src/app/ChatHistory.tsx
+++ b/contrib/chat-plugin/src/app/ChatHistory.tsx
@@ -114,13 +114,13 @@ const Message: React.FC<{ message: ChatMessage }> = ({ message }) => {
   };
 
   const hasExpandedRef = useRef(false);
-  
+
   useEffect(() => {
     if (message.message.length > 0 && !hasExpandedRef.current) {
       setExpanded(false);
       hasExpandedRef.current = true;
     }
-  }, [message.message.length])
+  }, [message.message.length]);
 
   return (
     <div className="flex-1 container relative mb-1 bg-gray-100 px-2 py-1 rounded word-wrap"    >
@@ -149,7 +149,7 @@ const Message: React.FC<{ message: ChatMessage }> = ({ message }) => {
       )}
       <div
         ref={contentRef}
-        className={`flex-1 'pr-10'  'overflow-auto' `}
+        className={`flex-1 pr-10 overflow-auto`}
         style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontFamily: 'inherit' }}
       >
         {message.message}

--- a/contrib/chat-plugin/src/libs/api.ts
+++ b/contrib/chat-plugin/src/libs/api.ts
@@ -265,14 +265,14 @@ export async function chatStreamRequest(abortSignal?: AbortSignal) {
               const parsed = JSON.parse(data);
 
               // Handle different response formats (e.g., chat completions vs completions)
-              const contentDelta = parsed.choices?.[0]?.delta?.content ||
+              let contentDelta = parsed.choices?.[0]?.delta?.content ||
                 parsed.choices?.[0]?.text ||
                 "";
               const reasonDelta = parsed.choices?.[0]?.delta?.reasoning_content || "";
 
               if (contentDelta) {
                 if (newMsg.message.length === 0) {
-                  contentDelta.trim();
+                  contentDelta = contentDelta.trim();
                 }
                 newMsg.message += contentDelta;
               }

--- a/contrib/chat-plugin/src/libs/state.ts
+++ b/contrib/chat-plugin/src/libs/state.ts
@@ -76,7 +76,7 @@ export const useChatStore = create<State>((set) => ({
     const chatMsgs = [...state.chatMsgs];
     if (chatMsgs.length > 0) {
       chatMsgs[chatMsgs.length - 1] = lastChat;
-    }else {
+    } else {
       chatMsgs.push(lastChat);
     }
     return { chatMsgs };


### PR DESCRIPTION
This pull request introduces support for displaying and streaming "reasoning" content alongside chat messages in the chat plugin. The changes ensure that both message and reasoning fields are handled throughout the chat flow, from API response parsing to UI rendering. Additionally, the message folding logic is simplified and improved to better handle long messages and reasoning sections.

**Reasoning support in chat messages:**

* Added an optional `reasoning` field to the `ChatMessage` type, allowing reasoning content to be stored and displayed with each chat message.
* Updated the message streaming logic in `chatStreamRequest` to parse and append both message and reasoning content from API responses, ensuring that reasoning is incrementally updated in the chat store. [[1]](diffhunk://#diff-6710221c38b8027d789a41039fd3591190c1a8e3bb78ed6f3305d71a8cc08ad1L218-R240) [[2]](diffhunk://#diff-6710221c38b8027d789a41039fd3591190c1a8e3bb78ed6f3305d71a8cc08ad1L268-R302)
* Modified the chat store's `updateLastChatMessage` method to update the entire `ChatMessage` object (including reasoning), rather than just the message string. [[1]](diffhunk://#diff-85ea428aac7d908712baa891a39fe098009b41ae2f7c8f23c83a4901a9fedfeaL46-R48) [[2]](diffhunk://#diff-85ea428aac7d908712baa891a39fe098009b41ae2f7c8f23c83a4901a9fedfeaL75-R82)

**UI improvements for message folding and reasoning display:**

* Refactored the `Message` component to display reasoning content in a collapsible section, removed the `expand` prop, and improved the logic for folding/unfolding long messages and reasoning.
* Updated message rendering in `MessageGroup` to use the new `Message` component signature without the `expand` prop.

**API enhancements:**

* Added a new `postStream` method to the API utility to support streaming POST requests with optional authorization, improving flexibility for future API interactions.