### PR TITLE
Feature: Make message showed as markdown in chat-plugin and copied as text

### DIFF
--- a/contrib/chat-plugin/src/app/ChatHistory.tsx
+++ b/contrib/chat-plugin/src/app/ChatHistory.tsx
@@ -165,11 +165,16 @@ const Message: React.FC<{ message: ChatMessage }> = ({ message }) => {
         {isHovered ? (
           <div>
             <button
-              onClick={() => {
+              onClick={async () => {
                 const textToCopy = message.reasoning
                   ? `<think>\n${message.reasoning}\n</think>\n\n${message.message}`
                   : message.message;
-                navigator.clipboard.writeText(textToCopy);
+                try {
+                  await navigator.clipboard.writeText(textToCopy);
+                } catch (err) {
+                  // Optionally, provide user feedback here
+                  console.error("Failed to copy to clipboard:", err);
+                }
               }}
               className="text-gray-500 hover:text-gray-700 transition-opacity"
               title="Copy message"
@@ -177,7 +182,7 @@ const Message: React.FC<{ message: ChatMessage }> = ({ message }) => {
               <ClipboardCopy size={16} />
             </button>
           </div>) :
-          (<div style={{ height: '24px' }}></div>)
+          ((<div className="h-6"></div>))
         }
       </div>
     </div>


### PR DESCRIPTION
This pull request enhances the chat message display in the `ChatHistory.tsx` component by improving the rendering of message content and adding a user-friendly copy-to-clipboard feature. The changes focus on better Markdown support, improved styling, and new interactivity for copying messages.

**UI/UX Improvements:**

* Added a copy-to-clipboard button that appears when hovering over a chat message, allowing users to easily copy the message content (including reasoning if present) to their clipboard.
* Improved message and reasoning rendering by replacing plain text with the `CustomMarkdown` component, enabling better Markdown formatting and display.
* Enhanced layout and styling for message containers, including better handling of overflow and maximum width for improved readability. [[1]](diffhunk://#diff-9d8810f7a83288a942f117307120f3aaa3ac8e3528c908850ca97bcd12cfe5b4L126-R136) [[2]](diffhunk://#diff-9d8810f7a83288a942f117307120f3aaa3ac8e3528c908850ca97bcd12cfe5b4L142-R181)

**Code and Dependency Updates:**

* Replaced the `SigmaIcon` import with `ClipboardCopy` from `lucide-react` to support the new copy feature, and removed unused icon imports.
* Introduced hover state management to control the visibility of the copy button.