### PR TITLE
Bring local disk back for Prometheus service

### DIFF
--- a/src/prometheus/config/prometheus.yaml
+++ b/src/prometheus/config/prometheus.yaml
@@ -20,7 +20,6 @@ service_type: "common"
 port: 9091
 scrape_interval: 30
 
-disk: pvc-prometheus-disk
 # # By default, do not enable the remote_write feature, which relies 
 # # on the azure monitor workspace and a managed identity 
 # remote_write:

--- a/src/prometheus/deploy/prometheus-deployment.yaml.template
+++ b/src/prometheus/deploy/prometheus-deployment.yaml.template
@@ -137,8 +137,6 @@ spec:
       - name: prometheus-blob
         persistentVolumeClaim:
           claimName: {{ cluster_cfg["prometheus"]["blob"] }}
-        hostPath:
-          path: {{ cluster_cfg["cluster"]["common"]["data-path"] }}/prometheus/blob
       {% endif %}
       tolerations:
       - key: node.kubernetes.io/memory-pressure


### PR DESCRIPTION
remove the default azure disk value so we can use local disk for Prometheus service