### PR TITLE
remove public-key checking

### DIFF
--- a/src/ssh-proxy/config/ssh_proxy.py
+++ b/src/ssh-proxy/config/ssh_proxy.py
@@ -17,9 +17,6 @@ class SshProxy(object):
                 return host_conf["hostip"]
 
     def validation_pre(self):
-        for k in ["public-key"]:
-            if k not in self.service_conf:
-                return False, f"{k} is not found in ssh-proxy service configuration"
         if not self.get_master_ip():
             return False, f"No master ip found"
         return True, None


### PR DESCRIPTION
When there is no ssh-proxy deployment in some clusters, the configuration of ['ssh-proxy']['public-key'] may be missing, which will cause errors when deploying other services. We remove this check to fix this problem.