### PR TITLE
Bug Fix: Change rest-server request and job-server request to internal url

### DIFF
--- a/src/model-proxy/deploy/model-proxy.yaml.template
+++ b/src/model-proxy/deploy/model-proxy.yaml.template
@@ -29,6 +29,9 @@ spec:
           - "--retry={{ cluster_cfg['model-proxy']['retry'] }}"
           - "--modelkey={{ cluster_cfg['model-proxy']['modelkey'] }}"
           - "--logdir=/usr/local/ltp/model-proxy/logs"
+        env:
+        - name: REST_SERVER_URI
+          value: {{ cluster_cfg["rest-server"]["uri"] }}
         volumeMounts:
         {%- if cluster_cfg['model-proxy']['log_pvc'] %}
         - name: model-proxy-log-storage

--- a/src/model-proxy/src/proxy/model_server.go
+++ b/src/model-proxy/src/proxy/model_server.go
@@ -9,16 +9,13 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
 
 // target job tag to identify model serving jobs
 const TARGET_JOB_TAG = "model-serving"
-
-// REST server and Job server path segments in the URL
-const REST_SERVER_PATH = "rest-server"
-const JOB_SERVER_PATH = "job-server"
 
 var httpClient = &http.Client{Timeout: 120 * time.Second}
 
@@ -128,7 +125,6 @@ func GetJobServerUrl(restServerUrl string, restServerToken string, jobId string)
 		return "", fmt.Errorf("no taskRoles found for job %s", jobId)
 	}
 
-	jobServerPath := strings.Replace(restServerUrl, REST_SERVER_PATH, JOB_SERVER_PATH, 1)
 	// Pick first role, first taskStatus
 	for _, role := range details.TaskRoles {
 		if len(role.TaskStatuses) == 0 {
@@ -143,7 +139,8 @@ func GetJobServerUrl(restServerUrl string, restServerToken string, jobId string)
 		if !ok || port == "" {
 			return "", fmt.Errorf("no http port found for job %s", jobId)
 		}
-		jobServerUrl := fmt.Sprintf("%s/%s:%s", jobServerPath, ts.ContainerIp, port)
+		// return the internal url
+		jobServerUrl := fmt.Sprintf("http://%s:%s", ts.ContainerIp, port)
 		return jobServerUrl, nil
 	}
 
@@ -233,7 +230,11 @@ func GetJobModelsMapping(req *http.Request, modelToken string) (map[string][]str
 	if req == nil || req.Host == "" {
 		return mapping, fmt.Errorf("invalid request or empty host")
 	}
-	restBase := fmt.Sprintf("https://%s/rest-server", req.Host)
+	// get rest server base url from the os environment variable
+	restBase := os.Getenv("REST_SERVER_URI")
+	if restBase == "" {
+		return mapping, fmt.Errorf("REST_SERVER_URI environment variable is not set")
+	}
 
 	restServerToken := req.Header.Get("Authorization")
 	jobIDs, err := ListModelServingJobs(restBase, restServerToken)

--- a/src/model-proxy/src/proxy/proxy.go
+++ b/src/model-proxy/src/proxy/proxy.go
@@ -75,9 +75,10 @@ func NewProxyHandler(config *types.Config) *ProxyHandler {
 
 // ReverseProxyHandler act as a reverse proxy, it will redirect the request to the destination website and return the response
 func (ph *ProxyHandler) ReverseProxyHandler(w http.ResponseWriter, r *http.Request) (string, []string, bool) {
-
+	log.Printf("[*] receive a request: %s %s\n", r.Method, r.URL.String())
 	// handle /healthz
 	if r.URL.Path == "/healthz" {
+		log.Printf("[*] receive a healthz request from %s\n", r.RemoteAddr)
 		w.WriteHeader(http.StatusOK)
 		if _, err := w.Write([]byte("ok")); err != nil {
 			log.Printf("[-] Error: failed to write healthz response: %v\n", err)
@@ -87,6 +88,7 @@ func (ph *ProxyHandler) ReverseProxyHandler(w http.ResponseWriter, r *http.Reque
 
 	// handle /v1/models
 	if r.URL.Path == "/v1/models" {
+		log.Printf("[*] receive a models list request from %s\n", r.RemoteAddr)
 		model2Url, err := GetJobModelsMapping(r, ph.authenticator.modelKey)
 		if err != nil {
 			log.Printf("[-] Error: failed to get models mapping: %v\n", err)


### PR DESCRIPTION
This pull request updates the model proxy service to improve configuration flexibility and logging, specifically by using an environment variable for the REST server URI and enhancing request logging. The most important changes are summarized below:

**Configuration and Environment Variables:**

* The REST server URI is now provided to the model proxy as an environment variable (`REST_SERVER_URI`), set via the deployment template (`model-proxy.yaml.template`). This allows for more flexible and dynamic configuration.
* The Go service (`model_server.go`) now reads the REST server base URL from the `REST_SERVER_URI` environment variable instead of constructing it from the request host, and returns an error if it is not set.

**Code Simplification and Refactoring:**

* Removed unused constants (`REST_SERVER_PATH`, `JOB_SERVER_PATH`) and simplified the way job server URLs are constructed, now directly using the container IP and port. [[1]](diffhunk://#diff-5d3114f5eec0e690f40a3dccfaca90ba11052f9a1aef67e6b7c0adbc6fb33847R12-L22) [[2]](diffhunk://#diff-5d3114f5eec0e690f40a3dccfaca90ba11052f9a1aef67e6b7c0adbc6fb33847L131) [[3]](diffhunk://#diff-5d3114f5eec0e690f40a3dccfaca90ba11052f9a1aef67e6b7c0adbc6fb33847L146-R143)

**Logging Improvements:**

* Added logging for incoming requests, including method and URL, as well as specific logs for `/healthz` and `/v1/models` endpoints, to improve observability and debugging. [[1]](diffhunk://#diff-7ea7651d9cba1f130a0c3afe9a480e58db74e4f62045fced9a044d04bf4eb72bL78-R81) [[2]](diffhunk://#diff-7ea7651d9cba1f130a0c3afe9a480e58db74e4f62045fced9a044d04bf4eb72bR91)