### PR TITLE
fix the problem that cluster-local-storage cannot get IPs of nodes

### DIFF
--- a/src/cluster-local-storage/deploy/cluster-local-storage.yaml.template
+++ b/src/cluster-local-storage/deploy/cluster-local-storage.yaml.template
@@ -23,7 +23,7 @@ spec:
       labels:
         app: cluster-local-storage-sts-{{ vc }}
     spec:
-      hostNetwork: true
+      hostNetwork: false
       serviceAccountName: cluster-local-storage-account
       nodeSelector:
         pai-master: "true"
@@ -61,6 +61,7 @@ spec:
         ports:
         - name: vcport-{{ loop.index0 }}
           containerPort: {{ vcport }}
+          hostPort: {{ vcport }}
         livenessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
The cluster-local-storage service cannot resolve the machine name to IP address. To solve this problem, we change the hostNetwork's value to false to use CoreDNS and mapping the service port to the node port.