### PR TITLE
Fix containers losing access to NVIDIA GPUs  

### DIFF
--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -550,7 +550,7 @@ const generateTaskRole = (
                 },
               ],
               securityContext: {
-                ...((dindMode) && { privileged: true }),
+                privileged: true,
                 capabilities: {
                   add: ['SYS_ADMIN', 'IPC_LOCK', 'DAC_READ_SEARCH'],
                   drop: ['MKNOD'],


### PR DESCRIPTION
Set priviledge as true for user jobs to avoid NVidia GPUs losing in containers.