### PR TITLE
fix: update AKS deploy bicep settings

### DIFF
--- a/contrib/aks/aks.bicep
+++ b/contrib/aks/aks.bicep
@@ -236,7 +236,7 @@ resource prometheusContainer 'Microsoft.Storage/storageAccounts/blobServices/con
 }
 
 // AKS
-resource aks 'Microsoft.ContainerService/managedClusters@2024-03-02-preview' = {
+resource aks 'Microsoft.ContainerService/managedClusters@2024-05-01' = {
   name: 'aks-openpai'
   location: location
   dependsOn: [

--- a/contrib/aks/provisionscript.bicep
+++ b/contrib/aks/provisionscript.bicep
@@ -2,7 +2,7 @@ param hubsub string
 param hubgroup string
 param extversion string
 
-resource aks 'Microsoft.ContainerService/managedClusters@2024-03-02-preview' existing = {
+resource aks 'Microsoft.ContainerService/managedClusters@2024-05-01' existing = {
   name: 'aks-openpai'
   scope: resourceGroup(hubsub, hubgroup)
 }


### PR DESCRIPTION
Microsoft.ContainerService/managedClusters@2024-03-02-preview is out-of-date, so we update it to Microsoft.ContainerService/managedClusters@2024-05-01